### PR TITLE
sentry-cli: Add Linux support

### DIFF
--- a/Formula/sentry-cli.rb
+++ b/Formula/sentry-cli.rb
@@ -1,13 +1,21 @@
 class SentryCli < Formula
-  desc "This is a Sentry command-line client for some generic tasks."
+  desc "Sentry command-line client for some generic tasks"
   homepage "https://github.com/getsentry/sentry-cli"
-  url "https://downloads.sentry-cdn.com/sentry-cli/1.51.1/sentry-cli-Darwin-x86_64"
   version "1.51.1"
-  sha256 "2fe8bcb052706153ff9e85e0af804ac1a35178c00d1efa9a5d66e418be8724df"
+
+  if OS.mac?
+    url "https://downloads.sentry-cdn.com/sentry-cli/1.51.1/sentry-cli-Darwin-x86_64"
+    sha256 "2fe8bcb052706153ff9e85e0af804ac1a35178c00d1efa9a5d66e418be8724df"
+  elsif Hardware::CPU.is_64_bit?
+    url "https://downloads.sentry-cdn.com/sentry-cli/1.51.1/sentry-cli-Linux-x86_64"
+    sha256 "b0a78458842ce6d7febe871ccadbe064f7bed27ef6b6f38a00d1faa7bfe59fd4"
+  else
+    url "https://downloads.sentry-cdn.com/sentry-cli/1.51.1/sentry-cli-Linux-i686"
+    sha256 "b0dc89bd9df6ba5cf5a7c21890d559fd47a25fd6d6b607b4942e9bfffb9b271b"
+  end
 
   def install
-    mv "sentry-cli-Darwin-x86_64", "sentry-cli"
-    bin.install "sentry-cli"
+    bin.install Dir["*"].first => "sentry-cli"
   end
 
   test do

--- a/Formula/sentry-cli.rb
+++ b/Formula/sentry-cli.rb
@@ -15,7 +15,7 @@ class SentryCli < Formula
   end
 
   def install
-    bin.install Dir["*"].first => "sentry-cli"
+    bin.install Dir["sentry-cli-*"].first => "sentry-cli"
   end
 
   test do


### PR DESCRIPTION
Hello, since `sentry-cli` has Linux binaries and Homebrew supports Linux, this PR adds Linux support to the formula.

I also fixed the description to fit Homebrew’s standards.


Note: this repository misses a `LICENSE` file.