### PR TITLE
Revert "release: sentry-cli 2.0.0-beta.0"

### DIFF
--- a/Formula/sentry-cli.rb
+++ b/Formula/sentry-cli.rb
@@ -1,27 +1,27 @@
 class SentryCli < Formula
   desc "Sentry command-line client for some generic tasks"
   homepage "https://github.com/getsentry/sentry-cli"
-  version "2.0.0-beta.0"
+  version "1.74.3"
   license "BSD-3-Clause"
   if OS.mac?
-    url "https://downloads.sentry-cdn.com/sentry-cli/2.0.0-beta.0/sentry-cli-Darwin-universal"
-    sha256 "e03a8bb2e20727b15e4119a3d400a9f2a6f1f398c9778180d6309a5c90e03be0"
+    url "https://downloads.sentry-cdn.com/sentry-cli/1.74.3/sentry-cli-Darwin-universal"
+    sha256 "ec665920219317a728093b30fd9c009dd64a8f49001d1d8434a46aa8ba5d0f12"
   elsif OS.linux?
     if Hardware::CPU.arm?
       if Hardware::CPU.is_64_bit?
-        url "https://downloads.sentry-cdn.com/sentry-cli/2.0.0-beta.0/sentry-cli-Linux-aarch64"
-        sha256 "59956827c710d5b052bfcf7173bfadb3e9df8f9e373247d444df4006416f4325"
+        url "https://downloads.sentry-cdn.com/sentry-cli/1.74.3/sentry-cli-Linux-aarch64"
+        sha256 "5f981d63bf6644973b85cf514381196b7a7089fec07e580be7530522728cf95f"
       else
-        url "https://downloads.sentry-cdn.com/sentry-cli/2.0.0-beta.0/sentry-cli-Linux-armv7"
-        sha256 "739a1def69101d0c253cf5b8dc4893ac9adf39d535060348ae12827da4494a2d"
+        url "https://downloads.sentry-cdn.com/sentry-cli/1.74.3/sentry-cli-Linux-armv7"
+        sha256 "c852fd2e1f402c3db0b269df17da7d14e8098c1c066ee09d342901c39862a36a"
       end
     elseif Hardware::CPU.intel?
       if Hardware::CPU.is_64_bit?
-        url "https://downloads.sentry-cdn.com/sentry-cli/2.0.0-beta.0/sentry-cli-Linux-x86_64"
-        sha256 "7e18bbb983bfdd866de99fa0d69eee79982e03d63fc0a8994f229ea176776178"
+        url "https://downloads.sentry-cdn.com/sentry-cli/1.74.3/sentry-cli-Linux-x86_64"
+        sha256 "2d2b4acc6bb644aef5d07bd8c96ffaa16207719355fbf1578833c6eeee912554"
       else
-        url "https://downloads.sentry-cdn.com/sentry-cli/2.0.0-beta.0/sentry-cli-Linux-i686"
-        sha256 "a9348ed89c3aaccc519ae52030743efd8d46fc3c0209d8a345fb39b3a6bc76bb"
+        url "https://downloads.sentry-cdn.com/sentry-cli/1.74.3/sentry-cli-Linux-i686"
+        sha256 "f1db03614ec2b15e9cafcd7f3f7a9aaee5291f420fe4981ea220dc1bb8ec479e"
       end
     else
       raise "Unsupported architecture"


### PR DESCRIPTION
Brew doesnt understand pre-releases, and it tries to install `2.0.0-beta.0` which is not out yet.

Fixes https://github.com/getsentry/sentry-cli/issues/1177