### PR TITLE
Revert "release: sentry-cli 1.74.4"

### DIFF
--- a/Formula/sentry-cli.rb
+++ b/Formula/sentry-cli.rb
@@ -1,27 +1,27 @@
 class SentryCli < Formula
   desc "Sentry command-line client for some generic tasks"
   homepage "https://github.com/getsentry/sentry-cli"
-  version "1.74.4"
+  version "2.0.4"
   license "BSD-3-Clause"
   if OS.mac?
-    url "https://downloads.sentry-cdn.com/sentry-cli/1.74.4/sentry-cli-Darwin-universal"
-    sha256 "2a68d4d8bde9c8288bdbf36972af0750c5283ef72c9d1ec3145611a3c63d8263"
+    url "https://downloads.sentry-cdn.com/sentry-cli/2.0.4/sentry-cli-Darwin-universal"
+    sha256 "283370a6bf7356a422f39ab805094edefe15f087d512c4579b60e584cf4a3e20"
   elsif OS.linux?
     if Hardware::CPU.arm?
       if Hardware::CPU.is_64_bit?
-        url "https://downloads.sentry-cdn.com/sentry-cli/1.74.4/sentry-cli-Linux-aarch64"
-        sha256 "3fdf9ff93fc5daca3f78dcb48c3da2f45051c368ee85bdf29358222489a6bcd4"
+        url "https://downloads.sentry-cdn.com/sentry-cli/2.0.4/sentry-cli-Linux-aarch64"
+        sha256 "e796a2d535cc59c6d72e5e19aa7604e964328b5a7e09a62f695e0d9acde9b07e"
       else
-        url "https://downloads.sentry-cdn.com/sentry-cli/1.74.4/sentry-cli-Linux-armv7"
-        sha256 "d6ff4881f688c130f937a8f8633bfb31dfbefe927adb10c22d8cb34342fd73af"
+        url "https://downloads.sentry-cdn.com/sentry-cli/2.0.4/sentry-cli-Linux-armv7"
+        sha256 "19ea3f1a843b37df82b310ab82e330f6f26e4ff8b20b4c98c2a47c894c2164ff"
       end
     elseif Hardware::CPU.intel?
       if Hardware::CPU.is_64_bit?
-        url "https://downloads.sentry-cdn.com/sentry-cli/1.74.4/sentry-cli-Linux-x86_64"
-        sha256 "7d0310369055eff794e0e22d43461b95e9d72b20a3d84c5d18b3270d105dadd0"
+        url "https://downloads.sentry-cdn.com/sentry-cli/2.0.4/sentry-cli-Linux-x86_64"
+        sha256 "46b6d913e3bfeccaf3170493942120a1b7b11b07c04e932b8fa643187c621fdf"
       else
-        url "https://downloads.sentry-cdn.com/sentry-cli/1.74.4/sentry-cli-Linux-i686"
-        sha256 "389c56a06a936a12f42a09827ffdda738fd8a761b87452664207515dde44d774"
+        url "https://downloads.sentry-cdn.com/sentry-cli/2.0.4/sentry-cli-Linux-i686"
+        sha256 "abb2f9daeb78ba01ae3f2c36e4d64fb54fd3e937683c25f980872331c2a0e1b3"
       end
     else
       raise "Unsupported architecture"


### PR DESCRIPTION
Our Brew releasing workflow doesn't understand to not publish itself when newer major is present, and it overrides it, which makes `1.x` patches the latest version

Fixes https://github.com/getsentry/homebrew-tools/issues/4
Fixes https://github.com/getsentry/sentry-cli/issues/1229